### PR TITLE
Updated for Rocky 9

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 MMC Records Release Notice
 ================================================================================
 
-The MMC records software in this release is compatible with EPICS base R3-14-12.
+The MMC records software in this release is compatible with EPICS base R7.0.3.1-2.0.
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,6 +1,10 @@
 #
 # RELEASE_NOTES
 #
+R2.0.0	2025-08-22
+	Bump to module versions
+	Add an include file unistd.h to mmcaRecord.cc
+
 R1.0.7	2017-08-23 Scott A. Stubbs
 	Bumped to latest modules
 

--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -14,9 +14,9 @@
 # ==========================================================
 # Define the version strings for all needed modules
 # ==========================================================
-ASYN_MODULE_VERSION     = R4.31-1.0.0
-BUSY_MODULE_VERSION     = R1.6.1-0.2.5
-USB_SN_MODULE_VERSION    = R1.0.3
+ASYN_MODULE_VERSION     = R4.42-1.0.0
+BUSY_MODULE_VERSION     = R1.7.2.1-0.1.7
+USB_SN_MODULE_VERSION   = R2.0.2
 
 # ==========================================================
 # External Support module path definitions

--- a/mmcApp/src/mmcaRecord.cc
+++ b/mmcApp/src/mmcaRecord.cc
@@ -19,6 +19,7 @@
 #include <math.h>
 #include <time.h>
 #include <errlog.h>
+#include <unistd.h>
 
 #define GEN_SIZE_OFFSET
 #include "mmcaRecord.h"


### PR DESCRIPTION
`ioc-common-mmc` is needed by several hutches for the Rocky 9 migration. This IOC depends on the MMC module. I made a couple of simple updates and MMC is building. Tested out these changes with ioc-common-mmc and the IOC is now building for rocky9 (and rhel7). 

These changes were made:

Updated modules to latest releases in configure/RELEASE.local

Added an include file `unistd.h` to mmcaRecord.cc
